### PR TITLE
Add incremental option for mlir build

### DIFF
--- a/python/tpu_perf/buildtree.py
+++ b/python/tpu_perf/buildtree.py
@@ -36,7 +36,7 @@ def check_buildtree():
     return ok
 
 class BuildTree:
-    def __init__(self, root, args = None):
+    def __init__(self, root, args):
         self.root = root
         self.global_config = global_config = read_config(root) or dict()
         global_config['root'] = root

--- a/python/tpu_perf/util.py
+++ b/python/tpu_perf/util.py
@@ -47,3 +47,7 @@ def format_seconds(s):
         ['hours', 'minutes', 'seconds'])
     ret = ' '.join(f'{v} {u}' for v, u in pairs if v) or '0 second'
     return f'{days} days {ret}' if days else ret
+
+def hash(cmd):
+    from hashlib import md5
+    return md5(cmd.encode()).hexdigest()


### PR DESCRIPTION
Add `--incremental` option in tpu_perf.build command, default is False.

When set to True, the CommandExecutor will compare the hash string of the old and new commands, and if they are equal and the flag_fn does not exist (indicating that the same command was executed successfully), the command will be skipped.